### PR TITLE
Control panel: give app subprocesses no stdin, so a first-run prompt cannot hang a run

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -176,7 +176,20 @@ def api_run(app: str, account: str = "primary", action: str = "pilot"):
         env = dict(os.environ, PYTHONUNBUFFERED="1", PYTHONIOENCODING="utf-8")
         try:
             proc = subprocess.Popen(
-                cmd, cwd=meta["dir"], stdout=subprocess.PIPE,
+                cmd, cwd=meta["dir"],
+                # No stdin. The panel cannot answer a prompt, so an app must
+                # not be able to ask: inheriting this server's terminal makes
+                # sys.stdin.isatty() true, and the app then asks "Whose
+                # account is this?" on a first run and waits forever for input
+                # nobody can give. Worse, input() writes its prompt without a
+                # newline, so the line-reader below never yields it - the page
+                # shows a run that started and then nothing at all.
+                # With no stdin, input() raises EOFError, the apps report that
+                # no interactive console is available, and the run ends. That
+                # matches what the panel already promises: a run that needs an
+                # answer ends rather than hanging.
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT, text=True, encoding="utf-8",
                 errors="replace", bufsize=1, env=env)
         except Exception as e:


### PR DESCRIPTION
## What this PR does

Fixes a control-panel hang: clicking **Login** (or any action) could start a run that produced **no output at all** and never finished, leaving every button disabled until the panel was restarted. One line of behaviour change — the app subprocess is given no stdin.

Independent of #4, which fixes a *different* cause of the same visible symptom (there, the sign-in browser inherited the launcher's stdout so the stream never reached EOF). Either can be merged without the other; if you'd rather have one PR for "Login hangs", I'm happy to fold this into #4.

## Type

- [ ] New provider app
- [ ] Fix for a provider whose site changed
- [x] Docs / other

## Safety checklist (required)

- [x] **Read-only.** No provider-facing code touched; only how the panel spawns a subprocess.
- [x] **No credential handling.**
- [x] **No private data committed.** One file, 14 lines added.
- [x] `core/tests` and every app's `tests/` still pass (no test touched this path; see below).

## Notes for reviewers

Reproduced on a first run of two different apps (`amazon` and a local WIP one), on macOS.

Two things combined:

1. The subprocess inherited the panel server's stdin — the terminal the panel was started from. So `sys.stdin.isatty()` was **true**, and an app on its first run asked *"Whose account is this?"* and waited for input that can only be typed into that terminal, which the person is not looking at.
2. `input()` writes its prompt with **no trailing newline**, and the reader here is `iter(proc.stdout.readline, "")`. A partial line is never yielded — so the page showed the `$ command` line and then nothing: no prompt, no error, no `event: done`.

The apps *already* handle a missing console — `ask()` catches `EOFError` and exits 3, and `core`'s `ensure_owner()` returns early when `sys.stdin` is not a tty. Neither could fire while a real tty was attached. `stdin=subprocess.DEVNULL` makes both work as designed, and the run **ends** instead of hanging — which is what `gui/README.md` already promises: *"If a run hits a mid-run 'please sign in again' prompt … it will end."*

Verified after the change: the Login stream ends with `event: done / data: 0` in about a second, and Pilot streams normally and exits 0.

**Consequence worth knowing:** the account-holder name is no longer *asked for* when an app is driven from the panel, so `owner` stays unset and the index CSV's "Account Holder" column stays blank. That was already the case for any non-interactive run (`ensure_owner` skipped). Users set it by running the app once from a terminal, or by editing `config.json`. Happy to add a note to `gui/README.md` if you'd like it documented there.

Not changed, but worth flagging for a future PR: because the reader is line-based, **any** app writing a partial line would still stall the display. Reading in chunks instead of lines would make the panel robust to that in general; that felt out of scope here.
